### PR TITLE
fix: variable is not assigned as option's value in error log script

### DIFF
--- a/bin/exampleDataFactory.js
+++ b/bin/exampleDataFactory.js
@@ -158,7 +158,7 @@ function copyExampleFiles() {
 function injectScriptForErrorCatch(content, filename) {
   const injectVariable = typeof globalErrorLogVariable === 'string' ? globalErrorLogVariable : 'errorLogs';
   const injectScriptString =
-    `var ${injectVariable}=[];window.onerror=function(o,r,e,n){errorLogs.push({message:o,source:r,lineno:e,colno:n})};`;
+    `var ${injectVariable}=[];window.onerror=function(o,r,e,n){${injectVariable}.push({message:o,source:r,lineno:e,colno:n})};`;
   const newContent = content.replace(/(\n?)(\s*)(<\/head>)/i, `$1$2$2<script>${injectScriptString}</script>$1$2$3`);
 
   fs.writeFileSync(filename, newContent, {encoding: 'utf-8'});

--- a/tuidoc.config.json
+++ b/tuidoc.config.json
@@ -34,7 +34,8 @@
     "filePath": "demo/examples",
     "titles": {
       "example01-default-template": "1. Default Template"
-    }
+    },
+    "globalErrorLogVariable": false
   },
   "pathPrefix": "toast-ui.doc"
 }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

When inserting an error log script to the example page, the variable that was not assigned with the value set in the `globalErrorLogVariable` option was fixed.

> Refs. https://github.com/nhn/toast-ui.doc/pull/3#discussion_r405223124

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
